### PR TITLE
Add robustness tests and further model improvements

### DIFF
--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
@@ -245,7 +245,7 @@ public class ECCController implements Initializable {
         }
 
         if (!isConnected.get())
-            connect();
+            Platform.runLater(this::connect);
 
         return elevatorState;
     }

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
@@ -129,7 +129,7 @@ public class ECCController implements Initializable {
     }
 
     private void log(String message) {
-        errorText.set(errorText.get() + message + "\n");
+        Platform.runLater(() -> errorText.set(errorText.get() + message + "\n"));
     }
 
     private void log(Throwable e, int level) {

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
@@ -291,10 +291,13 @@ public class ECCController implements Initializable {
 
             for (int i = 0; i < info.getNrOfFloors(); i++) {
                 var state = getFloorState(i);
-                floors[i].requestUp.set(state.isUpRequest());
-                floors[i].requestDown.set(state.isDownRequest());
-                floors[i].stopRequest.set(elevatorState.getCurrentFloorButtonsPressed().get(i));
-                floors[i].isServiced.set(servicedFloors.get(i));
+                if (state != null)
+                {
+                    floors[i].requestUp.set(state.isUpRequest());
+                    floors[i].requestDown.set(state.isDownRequest());
+                    floors[i].stopRequest.set(elevatorState.getCurrentFloorButtonsPressed().get(i));
+                    floors[i].isServiced.set(servicedFloors.get(i));
+                }
             }
         });
     }

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
@@ -184,7 +184,7 @@ public class ECCController implements Initializable {
 			position.setValue(elevatorState.getCurrentPosition());
 			weight.setValue(elevatorState.getCurrentWeight());
 			currentFloor.setValue(elevatorState.getCurrentFloor());
-			isDoorOpen.setValue(elevatorState.getCurrentDoorStatus() == DoorStatus.OPEN);
+			isDoorOpen.setValue(elevatorState.getCurrentDoorState() == DoorState.OPEN);
 			isDirectionUp.setValue(elevatorState.getCurrentDirection() == Direction.UP);
 
 			var servicedFloors = elevatorState.getServicedFloors();

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/gui/ECCController.java
@@ -2,7 +2,6 @@ package at.fhhagenberg.esd.sqe.ws20.gui;
 
 import at.fhhagenberg.esd.sqe.ws20.model.*;
 import at.fhhagenberg.esd.sqe.ws20.utils.ConnectionError;
-import at.fhhagenberg.esd.sqe.ws20.utils.ConnectionError;
 import javafx.application.Platform;
 import javafx.beans.property.*;
 import javafx.beans.value.ObservableValue;
@@ -135,9 +134,11 @@ public class ECCController implements Initializable {
 
     private void log(Throwable e, int level) {
         final String indent = "  ".repeat(level);
-        log(indent + e.getMessage().replace("\n", "\n" + indent));
-        if (e.getCause() != null)
-            log(e.getCause(), level + 1);
+        if (e.getMessage() != null) {
+            log(indent + e.getMessage().replace("\n", "\n" + indent));
+            if (e.getCause() != null)
+                log(e.getCause(), level + 1);
+        }
     }
 
     private void log(Throwable e) {
@@ -238,6 +239,7 @@ public class ECCController implements Initializable {
                 else
                     return null;
             }
+
             log(e);
             return null;
         }
@@ -280,6 +282,7 @@ public class ECCController implements Initializable {
             position.setValue(elevatorState.getCurrentPosition());
             weight.setValue(elevatorState.getCurrentWeight());
             currentFloor.setValue(elevatorState.getCurrentFloor());
+
             isDoorOpen.setValue(elevatorState.getCurrentDoorState() == DoorState.OPEN);
             isDirectionUp.setValue(elevatorState.getCurrentDirection() == Direction.UP);
             targetFloor.setValue(elevatorState.getTargetFloor());

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/DoorState.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/DoorState.java
@@ -2,7 +2,7 @@ package at.fhhagenberg.esd.sqe.ws20.model;
 
 import sqelevator.IElevator;
 
-public enum DoorStatus {
+public enum DoorState {
     OPEN(IElevator.ELEVATOR_DOORS_OPEN),
     CLOSED(IElevator.ELEVATOR_DOORS_CLOSED),
     OPENING(IElevator.ELEVATOR_DOORS_OPENING),
@@ -11,7 +11,7 @@ public enum DoorStatus {
 
     private final int value;
 
-    DoorStatus(int value) {
+    DoorState(int value) {
         this.value = value;
     }
 
@@ -19,11 +19,15 @@ public enum DoorStatus {
         return value;
     }
 
-    public static DoorStatus fromInt(int status) {
-        if (status == OPEN.getValue() || status == CLOSING.getValue()) {
+    public static DoorState fromInt(int status) {
+        if (status == OPEN.getValue()) {
             return OPEN;
-        } else if (status == CLOSED.getValue() || status == OPENING.getValue()) {
+        } else if (status == CLOSED.getValue()) {
             return CLOSED;
+        } else if (status == OPENING.getValue()) {
+            return OPENING;
+        } else if (status == CLOSING.getValue()) {
+            return CLOSING;
         }
 
         // Note: IElevatorRMI.java specifies more constants for different door status but the method

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ElevatorState.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ElevatorState.java
@@ -17,7 +17,7 @@ public class ElevatorState {
 
     // Non-movement related properties
     private int currentWeight;
-    private DoorStatus currentDoorStatus;
+    private DoorState currentDoorState;
     private List<Boolean> currentFloorButtonsPressed;
     private List<Boolean> servicedFloors;
 
@@ -99,12 +99,12 @@ public class ElevatorState {
         this.currentWeight = currentWeight;
     }
 
-    public DoorStatus getCurrentDoorStatus() {
-        return currentDoorStatus;
+    public DoorState getCurrentDoorState() {
+        return currentDoorState;
     }
 
-    public void setCurrentDoorStatus(DoorStatus currentDoorStatus) {
-        this.currentDoorStatus = currentDoorStatus;
+    public void setCurrentDoorState(DoorState currentDoorState) {
+        this.currentDoorState = currentDoorState;
     }
 
     public List<Boolean> getCurrentFloorButtonsPressed() {

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ModelMessages.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ModelMessages.java
@@ -13,8 +13,6 @@ public class ModelMessages {
     }
 
     public static String getString(String key, Object... args) {
-        MessageFormat formatter = new MessageFormat("");
-        formatter.applyPattern(RESOURCE_BUNDLE.getString(key));
-        return formatter.format(args);
+        return MessageFormat.format(RESOURCE_BUNDLE.getString(key), args);
     }
 }

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ModelMessages.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/model/ModelMessages.java
@@ -1,0 +1,20 @@
+package at.fhhagenberg.esd.sqe.ws20.model;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+public class ModelMessages {
+    private static final String BUNDLE_NAME = "at.fhhagenberg.esd.sqe.ws20.model_messages";
+
+    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+
+    private ModelMessages() {
+    }
+
+    public static String getString(String key, Object... args) {
+        MessageFormat formatter = new MessageFormat("");
+        formatter.applyPattern(RESOURCE_BUNDLE.getString(key));
+        return formatter.format(args);
+    }
+}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/CommunicationError.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/CommunicationError.java
@@ -1,0 +1,7 @@
+package at.fhhagenberg.esd.sqe.ws20.utils;
+
+public class CommunicationError extends ECCError {
+    public CommunicationError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ConnectionError.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ConnectionError.java
@@ -1,0 +1,7 @@
+package at.fhhagenberg.esd.sqe.ws20.utils;
+
+public class ConnectionError extends ECCError {
+    public ConnectionError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ECCError.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ECCError.java
@@ -1,0 +1,7 @@
+package at.fhhagenberg.esd.sqe.ws20.utils;
+
+public class ECCError extends RuntimeException {
+    public ECCError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ElevatorException.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ElevatorException.java
@@ -1,7 +1,0 @@
-package at.fhhagenberg.esd.sqe.ws20.utils;
-
-public class ElevatorException extends RuntimeException {
-    public ElevatorException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ElevatorRMIMock.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ElevatorRMIMock.java
@@ -1,6 +1,6 @@
 package at.fhhagenberg.esd.sqe.ws20.utils;
 
-import at.fhhagenberg.esd.sqe.ws20.model.DoorStatus;
+import at.fhhagenberg.esd.sqe.ws20.model.DoorState;
 import sqelevator.IElevator;
 
 import java.util.ArrayList;
@@ -96,9 +96,9 @@ public class ElevatorRMIMock implements IElevator {
         elevators.get(elevatorIdx).currentWeight = weight;
     }
 
-    public void setDoorStatus(int elevatorIdx, DoorStatus doorStatus) {
+    public void setDoorStatus(int elevatorIdx, DoorState doorState) {
         validateElevatorNumber(elevatorIdx);
-        elevators.get(elevatorIdx).doorStatus = doorStatus.getValue();
+        elevators.get(elevatorIdx).doorStatus = doorState.getValue();
     }
 
 

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevator.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevator.java
@@ -1,18 +1,14 @@
 package at.fhhagenberg.esd.sqe.ws20.utils;
 
-import at.fhhagenberg.esd.sqe.ws20.model.ModelMessages;
 import sqelevator.IElevator;
 
-import java.net.MalformedURLException;
-import java.rmi.Naming;
-import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 
 
 public class ManagedIElevator implements IElevator {
     private final ManagedIElevatorConnector connector;
     private IElevator elevatorRmi;
-    private boolean connected;
+    private boolean connected = false;
 
 
     public ManagedIElevator(String url) {
@@ -21,6 +17,10 @@ public class ManagedIElevator implements IElevator {
 
     public ManagedIElevator(IElevator elevator) {
         connector = new ManagedIElevatorConnector(elevator);
+    }
+
+    public ManagedIElevator(ManagedIElevatorConnector connector) {
+        this.connector = connector;
     }
 
 
@@ -36,6 +36,10 @@ public class ManagedIElevator implements IElevator {
         connector.connect();
         connected = true;
         elevatorRmi = connector.getElevatorRmi();
+    }
+
+    public boolean isConnected() {
+        return connected;
     }
 
 
@@ -194,34 +198,4 @@ public class ManagedIElevator implements IElevator {
         });
     }
 
-    static class ManagedIElevatorConnector {
-        private final String url;
-        private IElevator elevatorRmi;
-
-        public ManagedIElevatorConnector(String url) {
-            this.url = url;
-            this.elevatorRmi = null;
-        }
-
-        public ManagedIElevatorConnector(IElevator elevator) {
-            this.elevatorRmi = elevator;
-            this.url = null;
-        }
-
-        public void connect() {
-            if (url != null) {
-                try {
-                    elevatorRmi = (IElevator) Naming.lookup(url);
-                } catch (RemoteException | NotBoundException e) {
-                    throw new ConnectionError(ModelMessages.getString("failedToConnectToUrl", url), e);
-                } catch (MalformedURLException e) {
-                    throw new ConnectionError(ModelMessages.getString("malformedUrl", url), e);
-                }
-            }
-        }
-
-        public IElevator getElevatorRmi() {
-            return elevatorRmi;
-        }
-    }
 }

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevator.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevator.java
@@ -1,5 +1,6 @@
 package at.fhhagenberg.esd.sqe.ws20.utils;
 
+import at.fhhagenberg.esd.sqe.ws20.model.ModelMessages;
 import sqelevator.IElevator;
 
 import java.net.MalformedURLException;
@@ -7,8 +8,8 @@ import java.rmi.Naming;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 
-public class ManagedIElevator implements IElevator {
 
+public class ManagedIElevator implements IElevator {
     private final ManagedIElevatorConnector connector;
     private IElevator elevatorRmi;
     private boolean connected;
@@ -207,16 +208,14 @@ public class ManagedIElevator implements IElevator {
             this.url = null;
         }
 
-        public void connect(){
+        public void connect() {
             if (url != null) {
                 try {
                     elevatorRmi = (IElevator) Naming.lookup(url);
                 } catch (RemoteException | NotBoundException e) {
-                    // TODO: use localised strings as exception text!
-                    throw new RMIConnectionException("Failed to connect to RMI URL '" + url + "'.", e);
+                    throw new ConnectionError(ModelMessages.getString("failedToConnectToUrl", url), e);
                 } catch (MalformedURLException e) {
-                    // TODO: use localised strings as exception text!
-                    throw new RMIConnectionException("Malformed RMI URL '" + url + "'.", e);
+                    throw new ConnectionError(ModelMessages.getString("malformedUrl", url), e);
                 }
             }
         }

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevatorConnector.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/ManagedIElevatorConnector.java
@@ -1,0 +1,41 @@
+package at.fhhagenberg.esd.sqe.ws20.utils;
+
+import at.fhhagenberg.esd.sqe.ws20.model.ModelMessages;
+import sqelevator.IElevator;
+
+import java.net.MalformedURLException;
+import java.rmi.Naming;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+
+
+public class ManagedIElevatorConnector {
+    private final String url;
+    private IElevator elevatorRmi;
+
+    public ManagedIElevatorConnector(String url) {
+        this.url = url;
+        this.elevatorRmi = null;
+    }
+
+    public ManagedIElevatorConnector(IElevator elevator) {
+        this.elevatorRmi = elevator;
+        this.url = null;
+    }
+
+    public void connect() {
+        if (url != null) {
+            try {
+                elevatorRmi = (IElevator) Naming.lookup(url);
+            } catch (RemoteException | NotBoundException e) {
+                throw new ConnectionError(ModelMessages.getString("failedToConnectToUrl", url), e);
+            } catch (MalformedURLException e) {
+                throw new ConnectionError(ModelMessages.getString("malformedUrl", url), e);
+            }
+        }
+    }
+
+    public IElevator getElevatorRmi() {
+        return elevatorRmi;
+    }
+}

--- a/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/RMIConnectionException.java
+++ b/src/main/java/at/fhhagenberg/esd/sqe/ws20/utils/RMIConnectionException.java
@@ -1,7 +1,0 @@
-package at.fhhagenberg.esd.sqe.ws20.utils;
-
-public class RMIConnectionException extends RuntimeException {
-    public RMIConnectionException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -8,4 +8,5 @@ module at.fhhagenberg.sqe {
 
     exports at.fhhagenberg.esd.sqe.ws20.gui;
     opens at.fhhagenberg.esd.sqe.ws20.gui;
+    opens at.fhhagenberg.esd.sqe.ws20.model;
 }

--- a/src/main/resources/at/fhhagenberg/esd/sqe/ws20/model_messages.properties
+++ b/src/main/resources/at/fhhagenberg/esd/sqe/ws20/model_messages.properties
@@ -1,0 +1,8 @@
+generalInfoQueryFailed=Failed to query general information!
+elevatorStateQueryFailed=Failed to query elevator state!
+floorStateQueryFailed=Failed to query floor state!
+setServicedFloorsFailed=Failed to set serviced floors!
+setTargetFloorFailed=Failed to set serviced floors!
+maximumRetriesReached=Maximum number of retries reached!
+failedToConnectToUrl=Failed to connect to RMI URL '{0}'!
+malformedUrl=Malformed RMI URL '{0}'!

--- a/src/main/resources/at/fhhagenberg/esd/sqe/ws20/model_messages.properties
+++ b/src/main/resources/at/fhhagenberg/esd/sqe/ws20/model_messages.properties
@@ -4,5 +4,5 @@ floorStateQueryFailed=Failed to query floor state!
 setServicedFloorsFailed=Failed to set serviced floors!
 setTargetFloorFailed=Failed to set serviced floors!
 maximumRetriesReached=Maximum number of retries reached!
-failedToConnectToUrl=Failed to connect to RMI URL '{0}'!
-malformedUrl=Malformed RMI URL '{0}'!
+failedToConnectToUrl=Failed to connect to RMI URL ''{0}''!
+malformedUrl=Malformed RMI URL ''{0}''!

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/EndToEndTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/EndToEndTest.java
@@ -14,8 +14,6 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
-import java.util.Locale;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -32,9 +30,9 @@ public class EndToEndTest {
     private ECCPageObject page;
 
 
+    @SuppressWarnings("unused")
     @Start
     private void start(Stage stage) throws Exception {
-        Locale.setDefault(Locale.ENGLISH);
         new ECC(elevatorModel).start(stage);
     }
 

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
@@ -1,0 +1,77 @@
+package at.fhhagenberg.esd.sqe.ws20.gui;
+
+import at.fhhagenberg.esd.sqe.ws20.gui.pageobjects.ECCPageObject;
+import at.fhhagenberg.esd.sqe.ws20.model.Direction;
+import at.fhhagenberg.esd.sqe.ws20.model.DoorState;
+import at.fhhagenberg.esd.sqe.ws20.model.IElevatorWrapper;
+import at.fhhagenberg.esd.sqe.ws20.model.impl.ElevatorImpl;
+import at.fhhagenberg.esd.sqe.ws20.utils.ManagedIElevator;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import sqelevator.IElevator;
+
+import java.rmi.RemoteException;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+@ExtendWith(MockitoExtension.class)
+public class ErrorTest {
+
+    // TestFX may need additional VM options:
+    // --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+
+    @Mock
+    private IElevator mockElevator;
+    private IElevatorWrapper elevatorModel;
+
+    private ECCPageObject page;
+
+
+    @SuppressWarnings("unused")
+    @Start
+    private void start(Stage stage) throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(mockElevator.getElevatorDoorStatus(anyInt())).thenReturn(DoorState.OPEN.getValue());
+        when(mockElevator.getCommittedDirection(anyInt())).thenReturn(Direction.UP.getValue());
+        when(mockElevator.getElevatorNum()).thenReturn(1);
+
+        elevatorModel = new ElevatorImpl(new ManagedIElevator(mockElevator));
+        new ECC(elevatorModel).start(stage);
+    }
+
+    @BeforeEach
+    public void setup(FxRobot robot) {
+        page = new ECCPageObject(robot);
+    }
+
+
+    @Test
+    void testEmptyErrorLogAfterStartup() {
+        page.assertEmptyErrorLog();
+    }
+
+    @Test
+    void testNonEmptyErrorLogAfterException() throws RemoteException {
+        when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
+        page.selectElevator(0);
+        page.assertNonEmptyErrorLog();
+    }
+
+    @Test
+    void testRecurringErrors() throws RemoteException {
+        when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
+        page.assertNonEmptyErrorLogWithTimeout();
+        page.clearErrorLog();
+        page.assertNonEmptyErrorLogWithTimeout();
+    }
+}

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
@@ -24,7 +23,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(ApplicationExtension.class)
-@ExtendWith(MockitoExtension.class)
 public class ErrorTest {
 
     // TestFX may need additional VM options:
@@ -70,6 +68,7 @@ public class ErrorTest {
     @Test
     void testRecurringErrors() throws RemoteException {
         when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
+        page.selectElevator(0);
         page.assertNonEmptyErrorLogWithTimeout();
         page.clearErrorLog();
         page.assertNonEmptyErrorLogWithTimeout();

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ErrorTest.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(ApplicationExtension.class)
-public class ErrorTest {
+class ErrorTest {
 
     // TestFX may need additional VM options:
     // --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ModelUpdateTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ModelUpdateTest.java
@@ -9,14 +9,11 @@ import at.fhhagenberg.esd.sqe.ws20.utils.ElevatorRMIMock;
 import at.fhhagenberg.esd.sqe.ws20.utils.ManagedIElevator;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
-
-import java.util.Locale;
 
 
 @ExtendWith(ApplicationExtension.class)
@@ -34,7 +31,6 @@ public class ModelUpdateTest {
     @SuppressWarnings("unused")
     @Start
     private void start(Stage stage) throws Exception {
-        Locale.setDefault(Locale.ENGLISH);
         new ECC(elevatorModel).start(stage);
     }
 
@@ -45,10 +41,8 @@ public class ModelUpdateTest {
     }
 
 
-    @Disabled("The GUI behaviour does not yet match the behaviour described in this test.")
     @Test
     void testTargetFloorUpdating() {
-        // TODO: fix the GUI behaviour for this test to work!
         elevatorRMIMock.setTarget(0, 1);
         elevatorRMIMock.setTarget(1, 2);
 

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ModelUpdateTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/ModelUpdateTest.java
@@ -2,7 +2,7 @@ package at.fhhagenberg.esd.sqe.ws20.gui;
 
 import at.fhhagenberg.esd.sqe.ws20.gui.pageobjects.ECCPageObject;
 import at.fhhagenberg.esd.sqe.ws20.model.Direction;
-import at.fhhagenberg.esd.sqe.ws20.model.DoorStatus;
+import at.fhhagenberg.esd.sqe.ws20.model.DoorState;
 import at.fhhagenberg.esd.sqe.ws20.model.IElevatorWrapper;
 import at.fhhagenberg.esd.sqe.ws20.model.impl.ElevatorImpl;
 import at.fhhagenberg.esd.sqe.ws20.utils.ElevatorRMIMock;
@@ -31,6 +31,7 @@ public class ModelUpdateTest {
     private ECCPageObject page;
 
 
+    @SuppressWarnings("unused")
     @Start
     private void start(Stage stage) throws Exception {
         Locale.setDefault(Locale.ENGLISH);
@@ -113,14 +114,14 @@ public class ModelUpdateTest {
 
     @Test
     void testDoorStateUpdating() {
-        elevatorRMIMock.setDoorStatus(0, DoorStatus.CLOSED);
-        elevatorRMIMock.setDoorStatus(1, DoorStatus.OPEN);
+        elevatorRMIMock.setDoorStatus(0, DoorState.CLOSED);
+        elevatorRMIMock.setDoorStatus(1, DoorState.OPEN);
 
         page.selectElevator(0);
-        page.assertDoorStateWithTimeout(DoorStatus.CLOSED);
+        page.assertDoorStateWithTimeout(DoorState.CLOSED);
 
         page.selectElevator(1);
-        page.assertDoorStateWithTimeout(DoorStatus.OPEN);
+        page.assertDoorStateWithTimeout(DoorState.OPEN);
     }
 
     @Test

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/pageobjects/ECCPageObject.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/pageobjects/ECCPageObject.java
@@ -1,7 +1,7 @@
 package at.fhhagenberg.esd.sqe.ws20.gui.pageobjects;
 
 import at.fhhagenberg.esd.sqe.ws20.model.Direction;
-import at.fhhagenberg.esd.sqe.ws20.model.DoorStatus;
+import at.fhhagenberg.esd.sqe.ws20.model.DoorState;
 import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
@@ -179,19 +179,19 @@ public class ECCPageObject {
         assertCurrentWeight(expectedCurrentWeight);
     }
 
-    public void assertDoorState(DoorStatus expectedDoorState) {
-        if (expectedDoorState == DoorStatus.OPEN || expectedDoorState == DoorStatus.CLOSING) {
+    public void assertDoorState(DoorState expectedDoorState) {
+        if (expectedDoorState == DoorState.OPEN || expectedDoorState == DoorState.CLOSING) {
             FxAssert.verifyThat(doorStateOpenId, NodeMatchers.isVisible());
             FxAssert.verifyThat(doorStateClosedId, NodeMatchers.isInvisible());
-        } else if (expectedDoorState == DoorStatus.CLOSED || expectedDoorState == DoorStatus.OPENING) {
+        } else if (expectedDoorState == DoorState.CLOSED || expectedDoorState == DoorState.OPENING) {
             FxAssert.verifyThat(doorStateOpenId, NodeMatchers.isInvisible());
             FxAssert.verifyThat(doorStateClosedId, NodeMatchers.isVisible());
         }
     }
 
-    public void assertDoorStateWithTimeout(DoorStatus expectedDoorState) {
-        waitUntilVisibilityChanged(doorStateOpenId, expectedDoorState == DoorStatus.OPEN);
-        waitUntilVisibilityChanged(doorStateClosedId, expectedDoorState == DoorStatus.CLOSED);
+    public void assertDoorStateWithTimeout(DoorState expectedDoorState) {
+        waitUntilVisibilityChanged(doorStateOpenId, expectedDoorState == DoorState.OPEN);
+        waitUntilVisibilityChanged(doorStateClosedId, expectedDoorState == DoorState.CLOSED);
         assertDoorState(expectedDoorState);
     }
 

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/pageobjects/ECCPageObject.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/gui/pageobjects/ECCPageObject.java
@@ -92,7 +92,7 @@ public class ECCPageObject {
     }
 
     public void clearErrorLog() {
-        TextField errorLog = robot.lookup(errorTextAreaId).query();
+        TextInputControl errorLog = robot.lookup(errorTextAreaId).query();
         errorLog.clear();
     }
 
@@ -220,7 +220,7 @@ public class ECCPageObject {
     }
 
     public void assertEmptyErrorLog() {
-        TextField errorLog = robot.lookup(errorTextAreaId).query();
+        TextInputControl errorLog = robot.lookup(errorTextAreaId).query();
         assertTrue(errorLog.getText().isEmpty(), "Error log is not empty!");
     }
 
@@ -246,9 +246,7 @@ public class ECCPageObject {
                 return !textInput.getText().isEmpty();
             });
         } catch (TimeoutException ex) {
-            TextInputControl textInput = robot.lookup(query).query();
-            throw new AssertionFailedError("Text of TextInputControl '" + query + "' did not contain text as expected.",
-                    "", textInput.getText(), ex);
+            throw new AssertionFailedError("Text of TextInputControl '" + query + "' did not contain text as expected.", ex);
         }
     }
 

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
@@ -1,0 +1,77 @@
+package at.fhhagenberg.esd.sqe.ws20.model;
+
+import at.fhhagenberg.esd.sqe.ws20.model.impl.ElevatorImpl;
+import at.fhhagenberg.esd.sqe.ws20.utils.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sqelevator.IElevator;
+
+import java.rmi.RemoteException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ConnectionTest {
+
+    @Mock
+    private ManagedIElevatorConnector mockConnector;
+    @Mock
+    private IElevator mockElevator;
+
+    private ManagedIElevator managedElevator;
+    private IElevatorWrapper elevatorWrapper;
+
+
+    @BeforeEach
+    private void setup() throws RemoteException {
+        MockitoAnnotations.openMocks(this);
+        when(mockConnector.getElevatorRmi()).thenReturn(mockElevator);
+        when(mockElevator.getElevatorDoorStatus(anyInt())).thenReturn(DoorState.OPEN.getValue());
+        when(mockElevator.getCommittedDirection(anyInt())).thenReturn(Direction.UP.getValue());
+
+        managedElevator = new ManagedIElevator(mockConnector);
+        elevatorWrapper = new ElevatorImpl(managedElevator);
+    }
+
+
+    @Test
+    public void testConnectingAtFirstRequest() {
+        assertFalse(managedElevator.isConnected());
+
+        assertDoesNotThrow(() -> elevatorWrapper.queryElevatorState(0));
+
+        verify(mockConnector).connect();
+        assertTrue(managedElevator.isConnected());
+    }
+
+    @Test
+    public void testDisconnectingAfterFirstError() throws RemoteException {
+        elevatorWrapper.queryElevatorState(0);
+        clearInvocations(mockConnector);
+
+        when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
+
+        assertThrows(CommunicationError.class, () -> elevatorWrapper.queryElevatorState(0));
+        assertFalse(managedElevator.isConnected());
+        verifyNoInteractions(mockConnector);
+    }
+
+    @Test
+    public void testReconnectingAfterError() throws RemoteException {
+        elevatorWrapper.queryElevatorState(0);
+        when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
+        assertThrows(CommunicationError.class, () -> elevatorWrapper.queryElevatorState(0));
+        clearInvocations(mockConnector);
+
+        doReturn(0L).when(mockElevator).getClockTick();
+        assertDoesNotThrow(() -> elevatorWrapper.queryElevatorState(0));
+        verify(mockConnector).connect();
+
+        assertTrue(managedElevator.isConnected());
+    }
+}

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
@@ -19,16 +19,16 @@ import static org.mockito.Mockito.*;
 public class ConnectionTest {
 
     @Mock
-    private ManagedIElevatorConnector mockConnector;
+    public ManagedIElevatorConnector mockConnector;
     @Mock
-    private IElevator mockElevator;
+    public IElevator mockElevator;
 
-    private ManagedIElevator managedElevator;
-    private IElevatorWrapper elevatorWrapper;
+    public ManagedIElevator managedElevator;
+    public IElevatorWrapper elevatorWrapper;
 
 
     @BeforeEach
-    private void setup() throws RemoteException {
+    public void setup() throws RemoteException {
         MockitoAnnotations.openMocks(this);
         when(mockConnector.getElevatorRmi()).thenReturn(mockElevator);
         when(mockElevator.getElevatorDoorStatus(anyInt())).thenReturn(DoorState.OPEN.getValue());

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ConnectionTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class ConnectionTest {
+class ConnectionTest {
 
     @Mock
     public ManagedIElevatorConnector mockConnector;
@@ -40,7 +40,7 @@ public class ConnectionTest {
 
 
     @Test
-    public void testConnectingAtFirstRequest() {
+    void testConnectingAtFirstRequest() {
         assertFalse(managedElevator.isConnected());
 
         assertDoesNotThrow(() -> elevatorWrapper.queryElevatorState(0));
@@ -50,7 +50,7 @@ public class ConnectionTest {
     }
 
     @Test
-    public void testDisconnectingAfterFirstError() throws RemoteException {
+    void testDisconnectingAfterFirstError() throws RemoteException {
         elevatorWrapper.queryElevatorState(0);
         clearInvocations(mockConnector);
 
@@ -62,7 +62,7 @@ public class ConnectionTest {
     }
 
     @Test
-    public void testReconnectingAfterError() throws RemoteException {
+    void testReconnectingAfterError() throws RemoteException {
         elevatorWrapper.queryElevatorState(0);
         when(mockElevator.getClockTick()).thenThrow(RemoteException.class);
         assertThrows(CommunicationError.class, () -> elevatorWrapper.queryElevatorState(0));

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ElevatorImplTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/ElevatorImplTest.java
@@ -4,7 +4,7 @@ import at.fhhagenberg.esd.sqe.ws20.model.impl.ElevatorImpl;
 import at.fhhagenberg.esd.sqe.ws20.utils.ManagedIElevator;
 import sqelevator.IElevator;
 import at.fhhagenberg.esd.sqe.ws20.utils.BoolGenerator;
-import at.fhhagenberg.esd.sqe.ws20.utils.ElevatorException;
+import at.fhhagenberg.esd.sqe.ws20.utils.CommunicationError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +68,7 @@ public class ElevatorImplTest {
         when(mockedElevatorRMI.getElevatorNum()).thenReturn(5);
         when(mockedElevatorRMI.getFloorHeight()).thenReturn(1);
 
-        assertThrows(ElevatorException.class, () -> uut.queryGeneralInformation(0));
+        assertThrows(CommunicationError.class, () -> uut.queryGeneralInformation(0));
 
         verify(mockedElevatorRMI, times(2)).getClockTick();
         verify(mockedElevatorRMI).getFloorNum();
@@ -102,9 +102,9 @@ public class ElevatorImplTest {
         when(mockedElevatorRMI.getClockTick()).thenReturn(1L, 1L);
         when(mockedElevatorRMI.getFloorNum()).thenReturn(20);
         when(mockedElevatorRMI.getElevatorNum()).thenReturn(5);
-        when(mockedElevatorRMI.getFloorHeight()).thenThrow(ElevatorException.class);
+        when(mockedElevatorRMI.getFloorHeight()).thenThrow(CommunicationError.class);
 
-        assertThrows(ElevatorException.class, () -> uut.queryGeneralInformation(0));
+        assertThrows(CommunicationError.class, () -> uut.queryGeneralInformation(0));
 
         verify(mockedElevatorRMI).getClockTick();
         verify(mockedElevatorRMI).getFloorNum();
@@ -118,7 +118,7 @@ public class ElevatorImplTest {
         when(mockedElevatorRMI.getClockTick()).thenReturn(1L, 1L, 1L);
         when(mockedElevatorRMI.getFloorNum()).thenReturn(20, 20);
         when(mockedElevatorRMI.getElevatorNum()).thenReturn(5, 5);
-        when(mockedElevatorRMI.getFloorHeight()).thenThrow(ElevatorException.class).thenReturn(123);
+        when(mockedElevatorRMI.getFloorHeight()).thenThrow(CommunicationError.class).thenReturn(123);
 
         var generalInformation = uut.queryGeneralInformation(1);
 
@@ -135,9 +135,9 @@ public class ElevatorImplTest {
 
     @Test
     public void testDefaultRetryValueThrowing() throws RemoteException {
-        when(mockedElevatorRMI.getClockTick()).thenThrow(ElevatorException.class);
+        when(mockedElevatorRMI.getClockTick()).thenThrow(CommunicationError.class);
 
-        assertThrows(ElevatorException.class, () -> uut.queryGeneralInformation());
+        assertThrows(CommunicationError.class, () -> uut.queryGeneralInformation());
 
         verify(mockedElevatorRMI, times(ElevatorImpl.DEFAULT_MAXIMUM_RETRIES + 1)).getClockTick();
         verifyNoMoreInteractions(mockedElevatorRMI);
@@ -189,7 +189,7 @@ public class ElevatorImplTest {
     public void testThrowingQueryFloorState() throws RemoteException {
         when(mockedElevatorRMI.getClockTick()).thenReturn(1234L, 0L);
 
-        assertThrows(ElevatorException.class, () -> uut.queryFloorState(0, 0));
+        assertThrows(CommunicationError.class, () -> uut.queryFloorState(0, 0));
 
         verify(mockedElevatorRMI, times(2)).getClockTick();
         verify(mockedElevatorRMI).getFloorHeight();
@@ -259,8 +259,8 @@ public class ElevatorImplTest {
         assertEquals(15, elevatorState1.getTargetFloor());
         assertEquals(16, elevatorState0.getCurrentWeight());
         assertEquals(16, elevatorState1.getCurrentWeight());
-        assertEquals(DoorStatus.CLOSED, elevatorState0.getCurrentDoorStatus());
-        assertEquals(DoorStatus.CLOSED, elevatorState1.getCurrentDoorStatus());
+        assertEquals(DoorState.CLOSED, elevatorState0.getCurrentDoorState());
+        assertEquals(DoorState.CLOSED, elevatorState1.getCurrentDoorState());
         assertEquals(Arrays.asList(true, false, true), elevatorState0.getCurrentFloorButtonsPressed());
         assertEquals(Arrays.asList(false, true, false), elevatorState1.getCurrentFloorButtonsPressed());
         assertEquals(Arrays.asList(false, true, false), elevatorState0.getServicedFloors());
@@ -274,7 +274,7 @@ public class ElevatorImplTest {
         when(mockedElevatorRMI.getCommittedDirection(anyInt())).thenReturn(IElevator.ELEVATOR_DIRECTION_DOWN);
         when(mockedElevatorRMI.getElevatorDoorStatus(anyInt())).thenReturn(IElevator.ELEVATOR_DOORS_CLOSED);
 
-        assertThrows(ElevatorException.class, () -> uut.queryElevatorState(0, 0));
+        assertThrows(CommunicationError.class, () -> uut.queryElevatorState(0, 0));
 
         verify(mockedElevatorRMI, times(2)).getClockTick();
         verify(mockedElevatorRMI, times(1)).getElevatorCapacity(anyInt());
@@ -297,7 +297,7 @@ public class ElevatorImplTest {
     public void testThrowingSetServicedFloors1Floor() throws RemoteException {
         doThrow(RemoteException.class).when(mockedElevatorRMI).setServicesFloors(anyInt(), anyInt(), anyBoolean());
 
-        assertThrows(ElevatorException.class, () -> uut.setServicedFloors(10, 123, true));
+        assertThrows(CommunicationError.class, () -> uut.setServicedFloors(10, 123, true));
 
         verify(mockedElevatorRMI).setServicesFloors(10, 123, true);
         verifyNoMoreInteractions(mockedElevatorRMI);
@@ -363,7 +363,7 @@ public class ElevatorImplTest {
     public void testThrowingSetTargetFloorToCurrent() throws RemoteException {
         when(mockedElevatorRMI.getElevatorFloor(anyInt())).thenThrow(RemoteException.class);
 
-        assertThrows(ElevatorException.class, () -> uut.setTargetFloor(8, 10));
+        assertThrows(CommunicationError.class, () -> uut.setTargetFloor(8, 10));
 
         verify(mockedElevatorRMI).getElevatorFloor(8);
         verifyNoMoreInteractions(mockedElevatorRMI);

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/EnumTests.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/EnumTests.java
@@ -10,27 +10,27 @@ public class EnumTests {
 
     @Test
     public void testDoorStatusFromIntOpen() {
-        assertEquals(DoorStatus.OPEN, DoorStatus.fromInt(IElevator.ELEVATOR_DOORS_OPEN));
+        assertEquals(DoorState.OPEN, DoorState.fromInt(IElevator.ELEVATOR_DOORS_OPEN));
     }
 
     @Test
     public void testDoorStatusFromIntClosed() {
-        assertEquals(DoorStatus.CLOSED, DoorStatus.fromInt(IElevator.ELEVATOR_DOORS_CLOSED));
+        assertEquals(DoorState.CLOSED, DoorState.fromInt(IElevator.ELEVATOR_DOORS_CLOSED));
     }
 
     @Test
     public void testDoorStatusFromIntOpening() {
-        assertEquals(DoorStatus.CLOSED, DoorStatus.fromInt(IElevator.ELEVATOR_DOORS_OPENING));
+        assertEquals(DoorState.OPENING, DoorState.fromInt(IElevator.ELEVATOR_DOORS_OPENING));
     }
 
     @Test
     public void testDoorStatusFromIntClosing() {
-        assertEquals(DoorStatus.OPEN, DoorStatus.fromInt(IElevator.ELEVATOR_DOORS_CLOSING));
+        assertEquals(DoorState.CLOSING, DoorState.fromInt(IElevator.ELEVATOR_DOORS_CLOSING));
     }
 
     @Test
     public void testDoorStatusUnknown() {
-        assertThrows(IllegalArgumentException.class, () -> DoorStatus.fromInt(123));
+        assertThrows(IllegalArgumentException.class, () -> DoorState.fromInt(123));
     }
 
 

--- a/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/RMIConnectionTest.java
+++ b/src/test/java/at/fhhagenberg/esd/sqe/ws20/model/RMIConnectionTest.java
@@ -1,0 +1,36 @@
+package at.fhhagenberg.esd.sqe.ws20.model;
+
+import at.fhhagenberg.esd.sqe.ws20.model.impl.ElevatorImpl;
+import at.fhhagenberg.esd.sqe.ws20.utils.ConnectionError;
+import at.fhhagenberg.esd.sqe.ws20.utils.ManagedIElevator;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.rmi.Naming;
+import java.rmi.RemoteException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class RMIConnectionTest {
+
+    @Test
+    void testMalformedRMIUrl() {
+        final String malformedUrl = "rmi:/urlWithOnly1Slash";
+        var impl = new ElevatorImpl(new ManagedIElevator(malformedUrl));
+        assertThrows(ConnectionError.class, impl::queryGeneralInformation);
+    }
+
+    @Test
+    void testEndpointNotAvailable() {
+        final String unavailableUrl = "rmi://test/hopefullyUnavailableEndpoint";
+        try {
+            Naming.list(unavailableUrl);
+            fail("An endpoint for the given URL has been found, although non was expected.");
+        } catch (RemoteException | MalformedURLException ignored) {
+        }
+
+        var impl = new ElevatorImpl(new ManagedIElevator(unavailableUrl));
+        assertThrows(ConnectionError.class, impl::queryGeneralInformation);
+    }
+}


### PR DESCRIPTION
Use two different custom exception types for errors in the model:
- `CommunicationError`\
   Signals errors caused by the RMI communication itself the cause may be a RemoteException (if the RMI call itself failed), or a TimeoutException in case the maximum number of retries has been exceeded (and the data is still not consistent).
- `ConnectionError`\
  Connecting/reconnecting to the RMI registry failed.

Localize error messages, so they can be output to the user.